### PR TITLE
Fix changelog errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,4 @@ procedures. Do not edit the file manually.
 ## [v1.0.0] - 2026-04-08 
 
 ### BREAKING CHANGES ⚠️
-- release first public version of ZEN-creator on Py-PI [[🔀 PR #21](https://github.com/ZEN-universe/ZEN-garden/pull/21) @ZEN-robot]
-
-## [v0.0.1]
-
-The fist public release of ZEN-creator.
+- Release first public version of ZEN-creator on Py-PI.

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -81,7 +81,7 @@ def get_zen_garden_version(pyproject_toml_file: Path) -> str:
     Returns:
         The project version string (e.g. "1.2.3").
     """
-    # get ZEN-garden version
+    # get zen-creator version
     with open(pyproject_toml_file, "rb") as f:
         data = tomllib.load(f)
     version = data["project"]["version"]
@@ -115,7 +115,7 @@ def parse_changes_from_pr_body(
     # get pull request information
     pr_info = (
         f"[[🔀 PR #{pr_number}]"
-        f"(https://github.com/ZEN-universe/ZEN-garden/pull/{pr_number}) "
+        f"(https://github.com/ZEN-universe/ZEN-creator/pull/{pr_number}) "
         f"@{pr_author}]"
     )
     # Extract "Detailed list of changes" section
@@ -352,7 +352,7 @@ def update_changelog(
         semver_bump (str): Semantic version bump type.
         pr_number (str): Pull request number.
         pr_author (str): Pull request author username.
-        new_version (str): The new version of ZEN-garden
+        new_version (str): The new version of ZEN-creator
 
     Returns:
         str: The full updated changelog text.


### PR DESCRIPTION
## Summary

The changelog update did not work properly in the previous commit due to leftover remnants from ZEN-garden. This commit fixes this.

## Detailed list of changes

- chore: fix bugs in the automatic changelog updates. The previous version still had some relic references to ZEN-garden rather than ZEN-creator.

## Checklist

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.

