### PR TITLE
Make objects public and add py.typed file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/files/generated/
 
 # PyBuilder
 .pybuilder/

--- a/docs/files/api/carrier.rst
+++ b/docs/files/api/carrier.rst
@@ -1,0 +1,9 @@
+Carrier
+=======
+
+.. autoclass:: zen_creator.Carrier
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/compare_trees.rst
+++ b/docs/files/api/compare_trees.rst
@@ -1,0 +1,5 @@
+compare_trees
+=============
+
+.. autofunction:: zen_creator.compare_trees
+	:no-index:

--- a/docs/files/api/config.rst
+++ b/docs/files/api/config.rst
@@ -1,0 +1,9 @@
+Config
+======
+
+.. autoclass:: zen_creator.Config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/conversion_technology.rst
+++ b/docs/files/api/conversion_technology.rst
@@ -1,0 +1,9 @@
+ConversionTechnology
+====================
+
+.. autoclass:: zen_creator.ConversionTechnology
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/dataset.rst
+++ b/docs/files/api/dataset.rst
@@ -1,0 +1,9 @@
+Dataset
+=======
+
+.. autoclass:: zen_creator.Dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/dataset_collection.rst
+++ b/docs/files/api/dataset_collection.rst
@@ -1,0 +1,9 @@
+DatasetCollection
+=================
+
+.. autoclass:: zen_creator.DatasetCollection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/element.rst
+++ b/docs/files/api/element.rst
@@ -1,0 +1,9 @@
+Element
+=======
+
+.. autoclass:: zen_creator.Element
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/energy_system.rst
+++ b/docs/files/api/energy_system.rst
@@ -1,0 +1,9 @@
+EnergySystem
+============
+
+.. autoclass:: zen_creator.EnergySystem
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/model.rst
+++ b/docs/files/api/model.rst
@@ -1,0 +1,9 @@
+Model
+=====
+
+.. autoclass:: zen_creator.Model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/retrofitting_technology.rst
+++ b/docs/files/api/retrofitting_technology.rst
@@ -1,0 +1,9 @@
+RetrofittingTechnology
+======================
+
+.. autoclass:: zen_creator.RetrofittingTechnology
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/sector.rst
+++ b/docs/files/api/sector.rst
@@ -1,0 +1,9 @@
+Sector
+======
+
+.. autoclass:: zen_creator.Sector
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/storage_technology.rst
+++ b/docs/files/api/storage_technology.rst
@@ -1,0 +1,9 @@
+StorageTechnology
+=================
+
+.. autoclass:: zen_creator.StorageTechnology
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/techno_economic_dataset.rst
+++ b/docs/files/api/techno_economic_dataset.rst
@@ -1,0 +1,9 @@
+TechnoEconomicDataset
+=====================
+
+.. autoclass:: zen_creator.TechnoEconomicDataset
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/technology.rst
+++ b/docs/files/api/technology.rst
@@ -1,0 +1,9 @@
+Technology
+==========
+
+.. autoclass:: zen_creator.Technology
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/transport_technology.rst
+++ b/docs/files/api/transport_technology.rst
@@ -1,0 +1,9 @@
+TransportTechnology
+===================
+
+.. autoclass:: zen_creator.TransportTechnology
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :special-members: __init__
+   :no-index:

--- a/docs/files/api/zen_creator.rst
+++ b/docs/files/api/zen_creator.rst
@@ -1,0 +1,21 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   model
+   config
+   compare_trees
+   sector
+   element
+   technology
+   carrier
+   energy_system
+   conversion_technology
+   retrofitting_technology
+   storage_technology
+   transport_technology
+   dataset
+   dataset_collection
+   techno_economic_dataset

--- a/docs/files/developer_guide/installation.rst
+++ b/docs/files/developer_guide/installation.rst
@@ -36,7 +36,7 @@ repository.
 
 **Track the upstream repository:**
 
-In your terminal window, navigate to the folder in which ZEN-garden was
+In your terminal window, navigate to the folder in which ZEN-creator was
 installed (i.e. the folder where the file ``zen_creator_env.yml`` is located)::
 
     cd <path_to_zen_creator_repo>
@@ -46,18 +46,18 @@ Track the upstream repository by running the following lines in Git-Bash::
     git remote add upstream https://github.com/ZEN-universe/ZEN-creator.git
     git fetch upstream
 
-**Create the ZEN-garden conda environment:**
+**Create the ZEN-creator conda environment:**
 
 Open the Anaconda Prompt application. This is a terminal window provided by
 Anaconda which allows you to run Anaconda commands.
 
 In the Anaconda Prompt, change the directory to the root directory of your 
-local ZEN-garden repository i.e. the folder where the file 
+local ZEN-creator repository i.e. the folder where the file 
 ``zen_creator_env.yml`` is located::
 
   cd <path_to_zen_creator_repo>
 
-Now you can install the conda environment for zen-garden with the following 
+Now you can install the conda environment for zen-creator with the following 
 command::
 
   conda env create -f zen_creator_env.yml
@@ -67,11 +67,11 @@ successful, you can see the environment at
 ``C:\Users\<username>\anaconda3\envs`` or wherever Anaconda is installed.
 
 .. note::
-    If you forked the ZEN-garden repository and created the environment from 
+    If you forked the ZEN-creator repository and created the environment from 
     ``zen_creator_env.yml``, then the environment will by default be 
     called ``zen-creator-env``.
 
 .. note::
     We strongly recommend working with conda environments. When installing the 
-    zen-garden conda environment via the ``zen_creator_env.yml``, the ZEN-creator 
+    zen-creator conda environment via the ``zen_creator_env.yml``, the ZEN-creator 
     package, as well as all other dependencies, are installed automatically. 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,12 @@ Documentation
    files/developer_guide/workflow
    files/developer_guide/class_diagram
    files/developer_guide/add_new_params
+
+.. toctree::
+   :maxdepth: 1
+   :caption: API Reference
+
+   files/api/zen_creator
    
 .. toctree::
    :maxdepth: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.flit.module]
+name = "zen_creator"
+
+[tool.flit.sdist]
+include = ["zen_creator/py.typed"]
+
 [project]
 name = "zen_creator"
 version = "1.0.0"

--- a/zen_creator/__init__.py
+++ b/zen_creator/__init__.py
@@ -13,6 +13,7 @@ from .model import Model
 from .sectors import Sector
 from .utils.compare_trees import compare_trees
 from .utils.default_config import Config
+from .utils.attribute import Attribute
 
 __all__ = [
 	"Model",
@@ -30,4 +31,5 @@ __all__ = [
 	"Dataset",
 	"DatasetCollection",
 	"TechnoEconomicDataset",
+    "Attribute",
 ]

--- a/zen_creator/__init__.py
+++ b/zen_creator/__init__.py
@@ -1,35 +1,35 @@
 from .datasets import Dataset, DatasetCollection, TechnoEconomicDataset
 from .elements import (
-	Carrier,
-	ConversionTechnology,
-	Element,
-	EnergySystem,
-	RetrofittingTechnology,
-	StorageTechnology,
-	Technology,
-	TransportTechnology,
+    Carrier,
+    ConversionTechnology,
+    Element,
+    EnergySystem,
+    RetrofittingTechnology,
+    StorageTechnology,
+    Technology,
+    TransportTechnology,
 )
 from .model import Model
 from .sectors import Sector
+from .utils.attribute import Attribute
 from .utils.compare_trees import compare_trees
 from .utils.default_config import Config
-from .utils.attribute import Attribute
 
 __all__ = [
-	"Model",
-	"Config",
-	"compare_trees",
-	"Sector",
-	"Element",
-	"Technology",
-	"Carrier",
-	"ConversionTechnology",
-	"RetrofittingTechnology",
-	"EnergySystem",
-	"StorageTechnology",
-	"TransportTechnology",
-	"Dataset",
-	"DatasetCollection",
-	"TechnoEconomicDataset",
+    "Model",
+    "Config",
+    "compare_trees",
+    "Sector",
+    "Element",
+    "Technology",
+    "Carrier",
+    "ConversionTechnology",
+    "RetrofittingTechnology",
+    "EnergySystem",
+    "StorageTechnology",
+    "TransportTechnology",
+    "Dataset",
+    "DatasetCollection",
+    "TechnoEconomicDataset",
     "Attribute",
 ]

--- a/zen_creator/__init__.py
+++ b/zen_creator/__init__.py
@@ -1,0 +1,33 @@
+from .datasets import Dataset, DatasetCollection, TechnoEconomicDataset
+from .elements import (
+	Carrier,
+	ConversionTechnology,
+	Element,
+	EnergySystem,
+	RetrofittingTechnology,
+	StorageTechnology,
+	Technology,
+	TransportTechnology,
+)
+from .model import Model
+from .sectors import Sector
+from .utils.compare_trees import compare_trees
+from .utils.default_config import Config
+
+__all__ = [
+	"Model",
+	"Config",
+	"compare_trees",
+	"Sector",
+	"Element",
+	"Technology",
+	"Carrier",
+	"ConversionTechnology",
+	"RetrofittingTechnology",
+	"EnergySystem",
+	"StorageTechnology",
+	"TransportTechnology",
+	"Dataset",
+	"DatasetCollection",
+	"TechnoEconomicDataset",
+]

--- a/zen_creator/sectors.py
+++ b/zen_creator/sectors.py
@@ -18,10 +18,10 @@ class Sector(ABC):
     name: str
     _sector_registry: dict[str, Type[Sector]] = {}
 
-    def __init__(self):
-        self._elements = []
+    def __init__(self) -> None:
+        self._elements: list[type[Element]] = []
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)
         if not hasattr(cls, "name"):
             raise Exception(
@@ -29,7 +29,7 @@ class Sector(ABC):
             )
         Sector._sector_registry[cls.name] = cls
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Control how class will be displayed. Overwritting since singleton.
         """
@@ -40,7 +40,7 @@ class Sector(ABC):
         return self._elements
 
     @elements.setter
-    def elements(self, v):
+    def elements(self, v: list[type[Element]]) -> None:
         """
         Validates elements each time it is set.
 
@@ -58,103 +58,103 @@ class Sector(ABC):
 class Electricity(Sector):
     name = "electricity"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.elements = [
-            carriers.Electricity,
-            carriers.Heat,
-            carriers.Lignite,
-            conversion_technologies.Photovoltaics,
-            conversion_technologies.LigniteCoalPlant,
-            storage_technologies.PumpedHydro,
-            transport_technologies.PowerLine,
+            carriers.Electricity,  # type: ignore[attr-defined]
+            carriers.Heat,  # type: ignore[attr-defined]
+            carriers.Lignite,  # type: ignore[attr-defined]
+            conversion_technologies.Photovoltaics,  # type: ignore[attr-defined]
+            conversion_technologies.LigniteCoalPlant,  # type: ignore[attr-defined]
+            storage_technologies.PumpedHydro,  # type: ignore[attr-defined]
+            transport_technologies.PowerLine,  # type: ignore[attr-defined]
         ]
 
 
 class Heat(Sector):
     name = "heat"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.elements = [
-            carriers.Heat,
-            conversion_technologies.HeatPump,
-            conversion_technologies.ElectrodeBoiler,
+            carriers.Heat,  # type: ignore[attr-defined]
+            conversion_technologies.HeatPump,  # type: ignore[attr-defined]
+            conversion_technologies.ElectrodeBoiler,  # type: ignore[attr-defined]
         ]
 
 
 class PassengerTransport(Sector):
     name = "passenger_transport"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class TruckTransport(Sector):
     name = "truck_transport"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Shipping(Sector):
     name = "shipping"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Aviation(Sector):
     name = "aviation"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Refining(Sector):
     name = "refining"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Hydrogen(Sector):
     name = "hydrogen"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Methanol(Sector):
     name = "methanol"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Ammonia(Sector):
     name = "ammonia"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Carbon(Sector):
     name = "carbon"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Cement(Sector):
     name = "cement"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 
 class Steel(Sector):
     name = "steel"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()

--- a/zen_creator/utils/compare_trees.py
+++ b/zen_creator/utils/compare_trees.py
@@ -174,9 +174,7 @@ def build_file_map(root: str | Path) -> dict[Path, Path]:
 # ----------------------------
 
 
-def compare_trees(
-    dir1: str | Path, dir2: str | Path, raise_error: bool = True
-) -> bool:
+def compare_trees(dir1: str | Path, dir2: str | Path, raise_error: bool = True) -> bool:
     map1 = build_file_map(dir1)
     map2 = build_file_map(dir2)
 

--- a/zen_creator/utils/compare_trees.py
+++ b/zen_creator/utils/compare_trees.py
@@ -2,7 +2,7 @@
 import difflib
 import json
 from pathlib import Path
-from typing import List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -13,8 +13,8 @@ import pandas as pd
 TOLERANCE = 10**-12
 
 
-def json_diff(obj1, obj2, path=""):
-    diffs = []
+def json_diff(obj1: Any, obj2: Any, path: str = "") -> list[str]:
+    diffs: list[str] = []
 
     if (type(obj1) is not type(obj2)) and not (
         isinstance(obj1, int) and isinstance(obj2, float)  # exclude int -> float
@@ -69,7 +69,7 @@ def json_diff(obj1, obj2, path=""):
 # ----------------------------
 
 
-def text_diff(file1, file2):
+def text_diff(file1: str | Path, file2: str | Path) -> list[str]:
     with open(file1, "r", encoding="utf-8") as f1:
         lines1 = f1.readlines()
 
@@ -87,9 +87,9 @@ def text_diff(file1, file2):
 # ----------------------------
 
 
-def csv_diff(file1: str, file2: str, tol: float = 1e-10) -> List[str]:
+def csv_diff(file1: str | Path, file2: str | Path, tol: float = 1e-10) -> list[str]:
 
-    differences: List[str] = []
+    differences: list[str] = []
 
     # Load CSV files
     df1 = pd.read_csv(file1)
@@ -135,7 +135,7 @@ def csv_diff(file1: str, file2: str, tol: float = 1e-10) -> List[str]:
 # ----------------------------
 
 
-def compare_files(file1, file2):
+def compare_files(file1: Path, file2: Path) -> list[str]:
     ext = file1.suffix.lower()
 
     if ext == ".json":
@@ -159,9 +159,9 @@ def compare_files(file1, file2):
 # ----------------------------
 
 
-def build_file_map(root):
+def build_file_map(root: str | Path) -> dict[Path, Path]:
     root = Path(root)
-    file_map = {}
+    file_map: dict[Path, Path] = {}
     for path in root.rglob("*"):
         if path.is_file():
             rel = path.relative_to(root)
@@ -174,7 +174,9 @@ def build_file_map(root):
 # ----------------------------
 
 
-def compare_trees(dir1, dir2, raise_error=True) -> bool:
+def compare_trees(
+    dir1: str | Path, dir2: str | Path, raise_error: bool = True
+) -> bool:
     map1 = build_file_map(dir1)
     map2 = build_file_map(dir2)
 
@@ -182,7 +184,7 @@ def compare_trees(dir1, dir2, raise_error=True) -> bool:
 
     is_equal = True
 
-    log = []
+    log: list[str] = []
 
     for rel_path in sorted(all_paths):
         f1 = map1.get(rel_path)
@@ -195,6 +197,7 @@ def compare_trees(dir1, dir2, raise_error=True) -> bool:
             diffs = ["Only in Tree2"]
             is_equal = False
         else:
+            assert f1 is not None and f2 is not None
             diffs = compare_files(f1, f2)
 
         if diffs:

--- a/zen_creator/utils/singleton_registry_meta.py
+++ b/zen_creator/utils/singleton_registry_meta.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta
+from typing import Any
 
 
 class SingletonRegistryMeta(ABCMeta):
@@ -6,7 +7,7 @@ class SingletonRegistryMeta(ABCMeta):
 
     _registries: dict[type, dict[str, object]] = {}
 
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, *args: Any, **kwargs: Any) -> object:
         """
         Ensure singleton behavior per class.
         Creates a registry for this class type if it doesn't exist.
@@ -14,22 +15,24 @@ class SingletonRegistryMeta(ABCMeta):
         registry = cls._registries.setdefault(cls, {})
 
         # Check for existing instance in registry by name (if the name is set)
-        if getattr(cls, "name", None) in registry:
-            return registry[cls.name]
+        class_name = getattr(cls, "name", None)
+        if isinstance(class_name, str) and class_name in registry:
+            return registry[class_name]
 
         # Create a new instance using the parent class's `__call__`
         instance = super().__call__(*args, **kwargs)
 
         # Register the instance if it has a 'name' attribute
-        if hasattr(instance, "name"):
-            registry[instance.name] = instance
+        instance_name = getattr(instance, "name", None)
+        if isinstance(instance_name, str):
+            registry[instance_name] = instance
 
         # Check if the class has a parent (for subclassing support)
         cls._register_in_parents(instance)
 
         return instance
 
-    def _register_in_parents(cls, instance):
+    def _register_in_parents(cls, instance: object) -> None:
         """Register the instance in parent class registries, up to the first class
         with the SingletonRegistryMeta metaclass."""
         # Check if the class has a parent (for subclassing support)
@@ -42,8 +45,9 @@ class SingletonRegistryMeta(ABCMeta):
             parent_registry = parent_class._registries.setdefault(parent_class, {})
 
             # Only register in the parent registry if it's not already registered
-            if getattr(instance, "name", None) and instance.name not in parent_registry:
-                parent_registry[instance.name] = instance
+            instance_name = getattr(instance, "name", None)
+            if isinstance(instance_name, str) and instance_name not in parent_registry:
+                parent_registry[instance_name] = instance
 
             # Recursively register in the parent's parent (up the hierarchy) if
             # necessary
@@ -57,6 +61,6 @@ class SingletonRegistryMeta(ABCMeta):
         return registry[name]
 
     @property
-    def registry(cls):
+    def registry(cls) -> dict[str, object]:
         """Return all registered instances of this class type."""
         return dict(cls._registries.get(cls, {}))


### PR DESCRIPTION
## Summary

This commit adds certain "user-oriented" objects and methods to the __init__.py file of ZEN-creator. These objects and methods can thus be imported directly from the ZEN-creator module with clean syntax. 

This commit also revises the typehints of the public facing objects/methods and adds a py.typed file. This ensures that mypy views ZEN-creator as a typed module. 

## Detailed list of changes

- feat: add certain "user-oriented" objects and methods to the __init__.py file of ZEN-creator. These objects and methods can thus be imported directly from the ZEN-creator module with clean syntax. 
- feat: revise type hints of the public facing objects/methods and add a `py.typed` file. This ensures that MyPy views ZEN-creator as a typed module.

## Checklist

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.


### Code quality
- [x] Newly introduced dependencies are added to `pyproject.toml`.
- [x] Code changes have been tested locally and all tests pass.
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.
- [x] Type Checker  ``mypy .`` passes all checks.

