### PR TITLE
Add test for model.from_config()

### DIFF
--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -2,42 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Iterator
-
 import pytest
 
 from zen_creator.elements import Element
 
-# Global variable to store the clean registry state at session start
-_CLEAN_REGISTRY_STATE: dict[str, type] | None = None
-
-
-@pytest.fixture(scope="session", autouse=True)
-def save_clean_registry_state() -> Iterator[None]:
-    """Save the clean registry state at the beginning of the session.
-
-    This fixture runs once at the start of the entire test session and captures
-    the registry state BEFORE test_from_config.py's classes are imported.
-    This ensures we have a reference to the original, uncontaminated state.
-    """
-    global _CLEAN_REGISTRY_STATE
-    _CLEAN_REGISTRY_STATE = Element.get_registry().copy()
-    yield
-
 
 @pytest.fixture(autouse=True)
-def reset_element_registry() -> Iterator[None]:
+def reset_element_registry():
     """Reset element registry before each test to prevent cross-test pollution.
 
     This function-scoped fixture restores the clean registry state before
     each test runs, ensuring that custom element classes defined in test_from_config.py
     don't interfere with tests like test_crystal_ball.
     """
-    # Before the test: restore to the clean state
-    if _CLEAN_REGISTRY_STATE is not None:
-        Element.clear_registry()
-        Element.update_registry(_CLEAN_REGISTRY_STATE)
-
+    # Before the test: clear the registry to ensure no classes are registered
+    Element.clear_registry()
     yield
-
-    # After the test: we don't need to do anything special
+    # After the test: do nothing

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -1,0 +1,43 @@
+"""Pytest fixtures for end-to-end tests with registry isolation."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+
+from zen_creator.elements import Element
+
+# Global variable to store the clean registry state at session start
+_CLEAN_REGISTRY_STATE: dict[str, type] | None = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def save_clean_registry_state() -> Iterator[None]:
+    """Save the clean registry state at the beginning of the session.
+
+    This fixture runs once at the start of the entire test session and captures
+    the registry state BEFORE test_from_config.py's classes are imported.
+    This ensures we have a reference to the original, uncontaminated state.
+    """
+    global _CLEAN_REGISTRY_STATE
+    _CLEAN_REGISTRY_STATE = Element.get_registry().copy()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def reset_element_registry() -> Iterator[None]:
+    """Reset element registry before each test to prevent cross-test pollution.
+
+    This function-scoped fixture restores the clean registry state before
+    each test runs, ensuring that custom element classes defined in test_from_config.py
+    don't interfere with tests like test_crystal_ball.
+    """
+    # Before the test: restore to the clean state
+    if _CLEAN_REGISTRY_STATE is not None:
+        Element.clear_registry()
+        Element.update_registry(_CLEAN_REGISTRY_STATE)
+
+    yield
+
+    # After the test: we don't need to do anything special

--- a/tests/end_to_end/fixtures/config_existing_model.yaml
+++ b/tests/end_to_end/fixtures/config_existing_model.yaml
@@ -20,6 +20,7 @@ system:
 # add and remove technologies/carriers from the model
 elements:   
   insert:
+    energy_system: energy_system_existing_model
     set_sectors: []
     set_conversion_technologies: 
       - natural_gas_boiler

--- a/tests/end_to_end/fixtures/config_existing_model.yaml
+++ b/tests/end_to_end/fixtures/config_existing_model.yaml
@@ -8,7 +8,6 @@ system:
   set_nodes:
     - CH
     - DE
-
   reference_year: 2023
   unaggregated_time_steps_per_year: 96
   aggregated_time_steps_per_year: 96
@@ -46,9 +45,8 @@ elements:
 
 # settings for individual data sources
 data:
-  datasets:
-    ensoe_api:
-      api_key: ""
+  datasets: {}
+  dataset_collections: {}
 
 # settings that go into the energy_system folder
 energy_system:

--- a/tests/end_to_end/fixtures/existing_model_elements.py
+++ b/tests/end_to_end/fixtures/existing_model_elements.py
@@ -75,7 +75,7 @@ def _fixture_csv_source(attr_name: str) -> SourceInformation:
 class ExistingModelEnergySystem(EnergySystem):
     """Energy system that mirrors the existing_model fixture."""
 
-    name = "energy_system"
+    name = "energy_system_existing_model"
 
     def __init__(self, model: Model):
         super().__init__(model=model)

--- a/tests/end_to_end/fixtures/existing_model_elements.py
+++ b/tests/end_to_end/fixtures/existing_model_elements.py
@@ -1,0 +1,1199 @@
+"""Element class definitions for the existing_model fixture.
+
+This module contains custom Carrier, Technology, and EnergySystem classes
+that mirror the structure of the existing_model fixture. These classes are
+kept in a separate module to allow lazy importing in tests, preventing
+registry contamination between tests.
+
+To use these classes in a test:
+    import importlib
+    importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from zen_creator.datasets.datasets.metadata import MetaData, SourceInformation
+from zen_creator.elements import Carrier, ConversionTechnology, EnergySystem
+from zen_creator.elements.storage_technologies.storage_technology import (
+    StorageTechnology,
+)
+from zen_creator.elements.transport_technologies.transport_technology import (
+    TransportTechnology,
+)
+from zen_creator.model import Model
+from zen_creator.utils.attribute import Attribute
+
+FIXTURE_ROOT = Path(__file__).parent
+EXISTING_MODEL_PATH = FIXTURE_ROOT / "existing_model"
+
+
+def _fixture_csv(relative_path: str, index_col=0):
+    return pd.read_csv(EXISTING_MODEL_PATH / relative_path, index_col=index_col)
+
+
+def _fixture_metadeta(from_csv: bool = False) -> MetaData:
+    if from_csv:
+        name = "existing_model_csv"
+        title = "Existing Model CSV File"
+    else:
+        name = "existing_model"
+        title = "Existing Model"
+
+    return MetaData(
+        name=name,
+        title=title,
+        author=["RRE Lab"],
+        publication="ZEN Creator Test Cases",
+        publication_year=2026,
+        url="https://github.com/ZEN-universe/ZEN-creator",
+    )
+
+
+def _fixture_default_source(attr_name: str) -> list[SourceInformation]:
+    return [
+        SourceInformation(
+            description=(
+                f"Using default value for {attr_name} from the existing model fixture."
+            ),
+            metadata=_fixture_metadeta(),
+        )
+    ]
+
+
+def _fixture_csv_source(attr_name: str) -> SourceInformation:
+    return SourceInformation(
+        description=f"Using csv file for {attr_name} from the existing model fixture.",
+        metadata=_fixture_metadeta(from_csv=True),
+    )
+
+
+class ExistingModelEnergySystem(EnergySystem):
+    """Energy system that mirrors the existing_model fixture."""
+
+    name = "energy_system"
+
+    def __init__(self, model: Model):
+        super().__init__(model=model)
+
+    def _set_carbon_emissions_annual_limit(self) -> Attribute:
+        return Attribute(
+            name="carbon_emissions_annual_limit",
+            element=self,
+            default_value=np.inf,
+            unit="gigatons",
+            sources=_fixture_default_source("carbon_emissions_annual_limit"),
+        )
+
+    def _set_carbon_emissions_budget(self) -> Attribute:
+        return Attribute(
+            name="carbon_emissions_budget",
+            element=self,
+            default_value=4.2749370139006455,
+            unit="gigatons",
+            sources=_fixture_default_source("carbon_emissions_budget"),
+        )
+
+    def _set_carbon_emissions_cumulative_existing(self) -> Attribute:
+        return Attribute(
+            name="carbon_emissions_cumulative_existing",
+            element=self,
+            default_value=0.0,
+            unit="gigatons",
+            sources=_fixture_default_source("carbon_emissions_cumulative_existing"),
+        )
+
+    def _set_price_carbon_emissions(self) -> Attribute:
+        return Attribute(
+            name="price_carbon_emissions",
+            element=self,
+            default_value=0.0,
+            unit="Euro/tons",
+            sources=_fixture_default_source("price_carbon_emissions"),
+        )
+
+    def _set_price_carbon_emissions_budget_overshoot(self) -> Attribute:
+        return Attribute(
+            name="price_carbon_emissions_budget_overshoot",
+            element=self,
+            default_value=400.0,
+            unit="Euro/tons",
+            sources=_fixture_default_source("price_carbon_emissions_budget_overshoot"),
+        )
+
+    def _set_price_carbon_emissions_annual_overshoot(self) -> Attribute:
+        return Attribute(
+            name="price_carbon_emissions_annual_overshoot",
+            element=self,
+            default_value=np.inf,
+            unit="Euro/tons",
+            sources=_fixture_default_source("price_carbon_emissions_annual_overshoot"),
+        )
+
+    def _set_discount_rate(self) -> Attribute:
+        return Attribute(
+            name="discount_rate",
+            element=self,
+            default_value=0.06,
+            unit="1",
+            sources=_fixture_default_source("discount_rate"),
+        )
+
+    def _set_knowledge_spillover_rate(self) -> Attribute:
+        return Attribute(
+            name="knowledge_spillover_rate",
+            element=self,
+            default_value=0.025,
+            unit="1",
+            sources=_fixture_default_source("knowledge_spillover_rate"),
+        )
+
+    def _set_knowledge_depreciation_rate(self) -> Attribute:
+        return Attribute(
+            name="knowledge_depreciation_rate",
+            element=self,
+            default_value=0.1,
+            unit="1",
+            sources=_fixture_default_source("knowledge_depreciation_rate"),
+        )
+
+    def _set_market_share_unbounded(self) -> Attribute:
+        return Attribute(
+            name="market_share_unbounded",
+            element=self,
+            default_value=0.1,
+            unit="1",
+            sources=_fixture_default_source("market_share_unbounded"),
+        )
+
+    def _set_set_nodes(self) -> Attribute:
+        return Attribute(
+            name="set_nodes",
+            element=self,
+            default_value=None,
+            sources=_fixture_default_source("set_nodes"),
+        ).set_data(
+            source=_fixture_csv_source("set_nodes"),
+            df=_fixture_csv("energy_system/set_nodes.csv"),
+        )
+
+    def _set_set_edges(self) -> Attribute:
+        return Attribute(
+            name="set_edges",
+            element=self,
+            default_value=None,
+            sources=_fixture_default_source("set_edges"),
+        ).set_data(
+            source=_fixture_csv_source("set_edges"),
+            df=_fixture_csv("energy_system/set_edges.csv"),
+        )
+
+
+class ElectricityCarrier(Carrier):
+    """Carrier definition for electricity in the existing_model fixture."""
+
+    name = "electricity"
+
+    def __init__(self, model: Model, power_unit: str = "MW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_demand(self) -> Attribute:
+        return Attribute(
+            name="demand",
+            element=self,
+            default_value=50.0,
+            unit="GW",
+            sources=_fixture_default_source("demand"),
+        ).set_data(
+            source=_fixture_csv_source("demand"),
+            df=_fixture_csv("set_carriers/electricity/demand.csv"),
+        )
+
+    def _set_availability_import(self) -> Attribute:
+        return Attribute(
+            name="availability_import",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("availability_import"),
+        )
+
+    def _set_availability_export(self) -> Attribute:
+        return Attribute(
+            name="availability_export",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("availability_export"),
+        )
+
+    def _set_availability_import_yearly(self) -> Attribute:
+        return Attribute(
+            name="availability_import_yearly",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("availability_import_yearly"),
+        )
+
+    def _set_availability_export_yearly(self) -> Attribute:
+        return Attribute(
+            name="availability_export_yearly",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("availability_export_yearly"),
+        )
+
+    def _set_price_import(self) -> Attribute:
+        return Attribute(
+            name="price_import",
+            element=self,
+            default_value=30.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_import"),
+        )
+
+    def _set_price_export(self) -> Attribute:
+        return Attribute(
+            name="price_export",
+            element=self,
+            default_value=0.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_export"),
+        )
+
+    def _set_carbon_intensity_carrier_import(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_carrier_import",
+            element=self,
+            default_value=0.127,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_carrier_import"),
+        )
+
+    def _set_carbon_intensity_carrier_export(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_carrier_export",
+            element=self,
+            default_value=0.127,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_carrier_export"),
+        )
+
+    def _set_price_shed_demand(self) -> Attribute:
+        return Attribute(
+            name="price_shed_demand",
+            element=self,
+            default_value=1000.0,
+            unit="Euro/MWh",
+            sources=_fixture_default_source("price_shed_demand"),
+        )
+
+    def save_data(self):
+        super().save_data()
+        demand_2024 = _fixture_csv("set_carriers/electricity/demand_2024.csv")
+        demand_2024.to_csv(self.output_path / "demand_2024.csv")
+
+
+class HeatCarrier(Carrier):
+    """Carrier definition for heat in the existing_model fixture."""
+
+    name = "heat"
+
+    def __init__(self, model: Model, power_unit: str = "MW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_demand(self) -> Attribute:
+        return Attribute(
+            name="demand",
+            element=self,
+            default_value=100.0,
+            unit="GW",
+            sources=_fixture_default_source("demand"),
+        ).set_data(
+            source=_fixture_csv_source("demand"),
+            df=_fixture_csv("set_carriers/heat/demand.csv"),
+        )
+
+    def _set_availability_import(self) -> Attribute:
+        return Attribute(
+            name="availability_import",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("availability_import"),
+        )
+
+    def _set_availability_export(self) -> Attribute:
+        return Attribute(
+            name="availability_export",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("availability_export"),
+        )
+
+    def _set_availability_import_yearly(self) -> Attribute:
+        return Attribute(
+            name="availability_import_yearly",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("availability_import_yearly"),
+        )
+
+    def _set_availability_export_yearly(self) -> Attribute:
+        return Attribute(
+            name="availability_export_yearly",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("availability_export_yearly"),
+        )
+
+    def _set_price_import(self) -> Attribute:
+        return Attribute(
+            name="price_import",
+            element=self,
+            default_value=0.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_import"),
+        )
+
+    def _set_price_export(self) -> Attribute:
+        return Attribute(
+            name="price_export",
+            element=self,
+            default_value=0.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_export"),
+        )
+
+    def _set_carbon_intensity_carrier_import(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_carrier_import",
+            element=self,
+            default_value=0.0,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_carrier_import"),
+        )
+
+    def _set_carbon_intensity_carrier_export(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_carrier_export",
+            element=self,
+            default_value=0.0,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_carrier_export"),
+        )
+
+    def _set_price_shed_demand(self) -> Attribute:
+        return Attribute(
+            name="price_shed_demand",
+            element=self,
+            default_value=np.inf,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_shed_demand"),
+        )
+
+
+class NaturalGasCarrier(Carrier):
+    """Carrier definition for natural gas in the existing_model fixture."""
+
+    name = "natural_gas"
+
+    def __init__(self, model: Model, power_unit: str = "MW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_demand(self) -> Attribute:
+        return Attribute(
+            name="demand",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("demand"),
+        )
+
+    def _set_availability_import(self) -> Attribute:
+        return Attribute(
+            name="availability_import",
+            element=self,
+            default_value=np.inf,
+            unit="GW",
+            sources=_fixture_default_source("availability_import"),
+        ).set_data(
+            source=_fixture_csv_source("availability_import"),
+            df=_fixture_csv("set_carriers/natural_gas/availability_import.csv"),
+        )
+
+    def _set_availability_export(self) -> Attribute:
+        return Attribute(
+            name="availability_export",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("availability_export"),
+        )
+
+    def _set_availability_import_yearly(self) -> Attribute:
+        return Attribute(
+            name="availability_import_yearly",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("availability_import_yearly"),
+        )
+
+    def _set_availability_export_yearly(self) -> Attribute:
+        return Attribute(
+            name="availability_export_yearly",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("availability_export_yearly"),
+        )
+
+    def _set_price_import(self) -> Attribute:
+        return Attribute(
+            name="price_import",
+            element=self,
+            default_value=23.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_import"),
+        )
+
+    def _set_price_export(self) -> Attribute:
+        return Attribute(
+            name="price_export",
+            element=self,
+            default_value=0.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_export"),
+        )
+
+    def _set_carbon_intensity_carrier_import(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_carrier_import",
+            element=self,
+            default_value=0.2,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_carrier_import"),
+        )
+
+    def _set_carbon_intensity_carrier_export(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_carrier_export",
+            element=self,
+            default_value=0.2,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_carrier_export"),
+        )
+
+    def _set_price_shed_demand(self) -> Attribute:
+        return Attribute(
+            name="price_shed_demand",
+            element=self,
+            default_value=np.inf,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("price_shed_demand"),
+        )
+
+
+class NaturalGasBoiler(ConversionTechnology):
+    """Conversion technology for the existing_model fixture."""
+
+    name = "natural_gas_boiler"
+
+    def __init__(self, model: Model, power_unit: str = "GW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_reference_carrier(self) -> Attribute:
+        return Attribute(
+            name="reference_carrier",
+            element=self,
+            default_value=["heat"],
+            sources=_fixture_default_source("reference_carrier"),
+        )
+
+    def _set_input_carrier(self) -> Attribute:
+        return Attribute(
+            name="input_carrier",
+            element=self,
+            default_value=["natural_gas"],
+            sources=_fixture_default_source("input_carrier"),
+        )
+
+    def _set_output_carrier(self) -> Attribute:
+        return Attribute(
+            name="output_carrier",
+            element=self,
+            default_value=["heat"],
+            sources=_fixture_default_source("output_carrier"),
+        )
+
+    def _set_lifetime(self) -> Attribute:
+        return Attribute(
+            name="lifetime",
+            element=self,
+            default_value=24.0,
+            unit="1",
+            sources=_fixture_default_source("lifetime"),
+        )
+
+    def _set_conversion_factor(self) -> Attribute:
+        return Attribute(
+            name="conversion_factor",
+            element=self,
+            default_value=[{"natural_gas": {"default_value": 1.1, "unit": "GWh/GWh"}}],
+            sources=_fixture_default_source("conversion_factor"),
+        )
+
+    def _set_max_load(self) -> Attribute:
+        return Attribute(
+            name="max_load",
+            element=self,
+            default_value=1.0,
+            unit="1",
+            sources=_fixture_default_source("max_load"),
+        )
+
+    def _set_opex_specific_variable(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_variable",
+            element=self,
+            default_value=0.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("opex_specific_variable"),
+        )
+
+    def _set_opex_specific_fixed(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_fixed",
+            element=self,
+            default_value=87.6,
+            unit="Euro/kW",
+            sources=_fixture_default_source("opex_specific_fixed"),
+        )
+
+    def _set_capex_specific_conversion(self) -> Attribute:
+        return Attribute(
+            name="capex_specific_conversion",
+            element=self,
+            default_value=876.0,
+            unit="Euro/kW",
+            sources=_fixture_default_source("capex_specific_conversion"),
+        )
+
+
+class Photovoltaics(ConversionTechnology):
+    """Conversion technology for the existing_model fixture."""
+
+    name = "photovoltaics"
+
+    def __init__(self, model: Model, power_unit: str = "GW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_reference_carrier(self) -> Attribute:
+        return Attribute(
+            name="reference_carrier",
+            element=self,
+            default_value=["electricity"],
+            sources=_fixture_default_source("reference_carrier"),
+        )
+
+    def _set_input_carrier(self) -> Attribute:
+        return Attribute(
+            name="input_carrier",
+            element=self,
+            default_value=[],
+            sources=_fixture_default_source("input_carrier"),
+        )
+
+    def _set_output_carrier(self) -> Attribute:
+        return Attribute(
+            name="output_carrier",
+            element=self,
+            default_value=["electricity"],
+            sources=_fixture_default_source("output_carrier"),
+        )
+
+    def _set_lifetime(self) -> Attribute:
+        return Attribute(
+            name="lifetime",
+            element=self,
+            default_value=24.0,
+            unit="1",
+            sources=_fixture_default_source("lifetime"),
+        )
+
+    def _set_conversion_factor(self) -> Attribute:
+        return Attribute(
+            name="conversion_factor",
+            element=self,
+            default_value=[{"": {"default_value": 1.1, "unit": "GWh/GWh"}}],
+            sources=_fixture_default_source("conversion_factor"),
+        )
+
+    def _set_max_load(self) -> Attribute:
+        return Attribute(
+            name="max_load",
+            element=self,
+            default_value=1.0,
+            unit="1",
+            sources=_fixture_default_source("max_load"),
+        )
+
+    def _set_opex_specific_variable(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_variable",
+            element=self,
+            default_value=1.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("opex_specific_variable"),
+        )
+
+    def _set_opex_specific_fixed(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_fixed",
+            element=self,
+            default_value=0.07,
+            unit="Euro/MW",
+            sources=_fixture_default_source("opex_specific_fixed"),
+        )
+
+    def _set_capex_specific_conversion(self) -> Attribute:
+        return Attribute(
+            name="capex_specific_conversion",
+            element=self,
+            default_value=751.0,
+            unit="Euro/kW",
+            sources=_fixture_default_source("capex_specific_conversion"),
+        )
+
+
+class NaturalGasStorage(StorageTechnology):
+    """Storage technology for the existing_model fixture."""
+
+    name = "natural_gas_storage"
+
+    def __init__(self, model: Model, power_unit: str = "GW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_reference_carrier(self) -> Attribute:
+        return Attribute(
+            name="reference_carrier",
+            element=self,
+            default_value=["natural_gas"],
+            sources=_fixture_default_source("reference_carrier"),
+        )
+
+    def _set_lifetime(self) -> Attribute:
+        return Attribute(
+            name="lifetime",
+            element=self,
+            default_value=100.0,
+            unit="1",
+            sources=_fixture_default_source("lifetime"),
+        )
+
+    def _set_max_load(self) -> Attribute:
+        return Attribute(
+            name="max_load",
+            element=self,
+            default_value=1.0,
+            unit="1",
+            sources=_fixture_default_source("max_load"),
+        )
+
+    def _set_opex_specific_variable(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_variable",
+            element=self,
+            default_value=0.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("opex_specific_variable"),
+        )
+
+    def _set_opex_specific_fixed(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_fixed",
+            element=self,
+            default_value=135.74,
+            unit="kiloEuro/GW",
+            sources=_fixture_default_source("opex_specific_fixed"),
+        )
+
+    def _set_carbon_intensity_technology(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_technology",
+            element=self,
+            default_value=0.0,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_technology"),
+        )
+
+    def _set_efficiency_charge(self) -> Attribute:
+        return Attribute(
+            name="efficiency_charge",
+            element=self,
+            default_value=0.9746794344808963,
+            unit="1",
+            sources=_fixture_default_source("efficiency_charge"),
+        )
+
+    def _set_efficiency_discharge(self) -> Attribute:
+        return Attribute(
+            name="efficiency_discharge",
+            element=self,
+            default_value=0.9746794344808963,
+            unit="1",
+            sources=_fixture_default_source("efficiency_discharge"),
+        )
+
+    def _set_self_discharge(self) -> Attribute:
+        return Attribute(
+            name="self_discharge",
+            element=self,
+            default_value=0.0,
+            unit="1",
+            sources=_fixture_default_source("self_discharge"),
+        )
+
+    def _set_capex_specific_storage(self) -> Attribute:
+        return Attribute(
+            name="capex_specific_storage",
+            element=self,
+            default_value=238.68,
+            unit="Euro/kW",
+            sources=_fixture_default_source("capex_specific_storage"),
+        )
+
+    def _set_capex_specific_storage_energy(self) -> Attribute:
+        return Attribute(
+            name="capex_specific_storage_energy",
+            element=self,
+            default_value=3.43,
+            unit="Euro/kWh",
+            sources=_fixture_default_source("capex_specific_storage_energy"),
+        )
+
+    def _set_capacity_addition_min_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_addition_min_energy",
+            element=self,
+            default_value=0.0,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_addition_min_energy"),
+        )
+
+    def _set_capacity_addition_max_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_addition_max_energy",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_addition_max_energy"),
+        )
+
+    def _set_capacity_existing_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_existing_energy",
+            element=self,
+            default_value=0.0,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_existing_energy"),
+        )
+
+    def _set_capacity_limit_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_limit_energy",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_limit_energy"),
+        )
+
+    def _set_min_load_energy(self) -> Attribute:
+        return Attribute(
+            name="min_load_energy",
+            element=self,
+            default_value=0.0,
+            unit="1",
+            sources=_fixture_default_source("min_load_energy"),
+        )
+
+    def _set_max_load_energy(self) -> Attribute:
+        return Attribute(
+            name="max_load_energy",
+            element=self,
+            default_value=1.0,
+            unit="1",
+            sources=_fixture_default_source("max_load_energy"),
+        )
+
+    def _set_capacity_investment_existing_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_investment_existing_energy",
+            element=self,
+            default_value=0.0,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_investment_existing_energy"),
+        )
+
+    def _set_opex_specific_fixed_energy(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_fixed_energy",
+            element=self,
+            default_value=55.54,
+            unit="Euro/MWh",
+            sources=_fixture_default_source("opex_specific_fixed_energy"),
+        )
+
+    def _set_energy_to_power_ratio_min(self) -> Attribute:
+        return Attribute(
+            name="energy_to_power_ratio_min",
+            element=self,
+            default_value=700.0,
+            unit="h",
+            sources=_fixture_default_source("energy_to_power_ratio_min"),
+        )
+
+    def _set_energy_to_power_ratio_max(self) -> Attribute:
+        return Attribute(
+            name="energy_to_power_ratio_max",
+            element=self,
+            default_value=700.0,
+            unit="h",
+            sources=_fixture_default_source("energy_to_power_ratio_max"),
+        )
+
+    def _set_flow_storage_inflow(self) -> Attribute:
+        return Attribute(
+            name="flow_storage_inflow",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("flow_storage_inflow"),
+        )
+
+
+class PumpedHydro(StorageTechnology):
+    """Storage technology for the existing_model fixture."""
+
+    name = "pumped_hydro"
+
+    def __init__(self, model: Model, power_unit: str = "GW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_reference_carrier(self) -> Attribute:
+        return Attribute(
+            name="reference_carrier",
+            element=self,
+            default_value=["electricity"],
+            sources=_fixture_default_source("reference_carrier"),
+        )
+
+    def _set_lifetime(self) -> Attribute:
+        return Attribute(
+            name="lifetime",
+            element=self,
+            default_value=55.0,
+            unit="1",
+            sources=_fixture_default_source("lifetime"),
+        )
+
+    def _set_max_load(self) -> Attribute:
+        return Attribute(
+            name="max_load",
+            element=self,
+            default_value=1.0,
+            unit="1",
+            sources=_fixture_default_source("max_load"),
+        )
+
+    def _set_opex_specific_variable(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_variable",
+            element=self,
+            default_value=10.0,
+            unit="Euro/MWh",
+            sources=_fixture_default_source("opex_specific_variable"),
+        )
+
+    def _set_opex_specific_fixed(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_fixed",
+            element=self,
+            default_value=7.5883468159272995,
+            unit="Euro/kW",
+            sources=_fixture_default_source("opex_specific_fixed"),
+        ).set_data(
+            source=_fixture_csv_source("opex_specific_fixed"),
+            df=_fixture_csv(
+                "set_technologies/set_storage_technologies/pumped_hydro/opex_specific_fixed.csv"
+            ),
+        )
+
+    def _set_carbon_intensity_technology(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_technology",
+            element=self,
+            default_value=0.0,
+            unit="kilotons/GWh",
+            sources=_fixture_default_source("carbon_intensity_technology"),
+        )
+
+    def _set_efficiency_charge(self) -> Attribute:
+        return Attribute(
+            name="efficiency_charge",
+            element=self,
+            default_value=0.8831760866327847,
+            unit="1",
+            sources=_fixture_default_source("efficiency_charge"),
+        )
+
+    def _set_efficiency_discharge(self) -> Attribute:
+        return Attribute(
+            name="efficiency_discharge",
+            element=self,
+            default_value=0.8831760866327847,
+            unit="1",
+            sources=_fixture_default_source("efficiency_discharge"),
+        )
+
+    def _set_self_discharge(self) -> Attribute:
+        return Attribute(
+            name="self_discharge",
+            element=self,
+            default_value=0.1,
+            unit="1",
+            sources=_fixture_default_source("self_discharge"),
+        )
+
+    def _set_capex_specific_storage(self) -> Attribute:
+        return Attribute(
+            name="capex_specific_storage",
+            element=self,
+            default_value=1070.9054443977402,
+            unit="Euro/kW",
+            sources=_fixture_default_source("capex_specific_storage"),
+        )
+
+    def _set_capex_specific_storage_energy(self) -> Attribute:
+        return Attribute(
+            name="capex_specific_storage_energy",
+            element=self,
+            default_value=75.883468159273,
+            unit="Euro/kWh",
+            sources=_fixture_default_source("capex_specific_storage_energy"),
+        )
+
+    def _set_capacity_addition_min_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_addition_min_energy",
+            element=self,
+            default_value=0.0,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_addition_min_energy"),
+        )
+
+    def _set_capacity_addition_max_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_addition_max_energy",
+            element=self,
+            default_value=np.inf,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_addition_max_energy"),
+        )
+
+    def _set_capacity_existing_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_existing_energy",
+            element=self,
+            default_value=0.0,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_existing_energy"),
+        ).set_data(
+            source=_fixture_csv_source("capacity_existing_energy"),
+            df=_fixture_csv(
+                "set_technologies/set_storage_technologies/pumped_hydro/capacity_existing_energy.csv",
+                index_col=[0, 1],
+            ),
+        )
+
+    def _set_capacity_existing(self) -> Attribute:
+        return Attribute(
+            name="capacity_existing",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("capacity_existing"),
+        ).set_data(
+            source=_fixture_csv_source("capacity_existing"),
+            df=_fixture_csv(
+                "set_technologies/set_storage_technologies/pumped_hydro/capacity_existing.csv",
+                index_col=[0, 1],
+            ),
+        )
+
+    def _set_capacity_limit_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_limit_energy",
+            element=self,
+            default_value=0.0,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_limit_energy"),
+        )
+
+    def _set_capacity_limit(self) -> Attribute:
+        return Attribute(
+            name="capacity_limit",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("capacity_limit"),
+        )
+
+    def _set_min_load_energy(self) -> Attribute:
+        return Attribute(
+            name="min_load_energy",
+            element=self,
+            default_value=0.0,
+            unit="1",
+            sources=_fixture_default_source("min_load_energy"),
+        )
+
+    def _set_max_load_energy(self) -> Attribute:
+        return Attribute(
+            name="max_load_energy",
+            element=self,
+            default_value=1.0,
+            unit="1",
+            sources=_fixture_default_source("max_load_energy"),
+        )
+
+    def _set_capacity_investment_existing_energy(self) -> Attribute:
+        return Attribute(
+            name="capacity_investment_existing_energy",
+            element=self,
+            default_value=0.0,
+            unit="GWh",
+            sources=_fixture_default_source("capacity_investment_existing_energy"),
+        )
+
+    def _set_opex_specific_fixed_energy(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_fixed_energy",
+            element=self,
+            default_value=1.0,
+            unit="Euro/MWh",
+            sources=_fixture_default_source("opex_specific_fixed_energy"),
+        )
+
+    def _set_flow_storage_inflow(self) -> Attribute:
+        return Attribute(
+            name="flow_storage_inflow",
+            element=self,
+            default_value=0.0,
+            unit="GW",
+            sources=_fixture_default_source("flow_storage_inflow"),
+        ).set_data(
+            source=_fixture_csv_source("flow_storage_inflow"),
+            df=_fixture_csv(
+                "set_technologies/set_storage_technologies/pumped_hydro/flow_storage_inflow.csv"
+            ),
+        )
+
+
+class NaturalGasPipeline(TransportTechnology):
+    """Transport technology for the existing_model fixture."""
+
+    name = "natural_gas_pipeline"
+
+    def __init__(self, model: Model, power_unit: str = "GW"):
+        super().__init__(model=model, power_unit=power_unit)
+
+    def _set_reference_carrier(self) -> Attribute:
+        return Attribute(
+            name="reference_carrier",
+            element=self,
+            default_value=["natural_gas"],
+            sources=_fixture_default_source("reference_carrier"),
+        )
+
+    def _set_lifetime(self) -> Attribute:
+        return Attribute(
+            name="lifetime",
+            element=self,
+            default_value=50.0,
+            unit="1",
+            sources=_fixture_default_source("lifetime"),
+        )
+
+    def _set_max_load(self) -> Attribute:
+        return Attribute(
+            name="max_load",
+            element=self,
+            default_value=1.0,
+            unit="1",
+            sources=_fixture_default_source("max_load"),
+        )
+
+    def _set_opex_specific_variable(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_variable",
+            element=self,
+            default_value=0.0,
+            unit="kiloEuro/GWh",
+            sources=_fixture_default_source("opex_specific_variable"),
+        )
+
+    def _set_opex_specific_fixed(self) -> Attribute:
+        return Attribute(
+            name="opex_specific_fixed",
+            element=self,
+            default_value=0.0,
+            unit="Euro/MW",
+            sources=_fixture_default_source("opex_specific_fixed"),
+        )
+
+    def _set_carbon_intensity_technology(self) -> Attribute:
+        return Attribute(
+            name="carbon_intensity_technology",
+            element=self,
+            default_value=0.0,
+            unit="kilotons/GWh/km",
+            sources=_fixture_default_source("carbon_intensity_technology"),
+        )
+
+    def _set_transport_loss_factor_linear(self) -> Attribute:
+        return Attribute(
+            name="transport_loss_factor_linear",
+            element=self,
+            default_value=5e-05,
+            unit="1/km",
+            sources=_fixture_default_source("transport_loss_factor_linear"),
+        )
+
+    def _set_capex_per_distance_transport(self) -> Attribute:
+        return Attribute(
+            name="capex_per_distance_transport",
+            element=self,
+            default_value=265.0,
+            unit="Euro/km/MW",
+            sources=_fixture_default_source("capex_per_distance_transport"),
+        )
+
+    def _set_distance(self) -> Attribute:
+        return Attribute(
+            name="distance",
+            element=self,
+            default_value=np.inf,
+            unit="km",
+            sources=_fixture_default_source("distance"),
+        )

--- a/tests/end_to_end/test_from_config.py
+++ b/tests/end_to_end/test_from_config.py
@@ -25,27 +25,33 @@ def test_from_config():
     Note: Element classes are imported locally to prevent global registry
     contamination when this test runs alongside other tests.
     """
-    # Import element classes locally to prevent registry contamination
-    # from tests.end_to_end.existing_model_elements import (
-    #     ExistingModelEnergySystem,
-    #     ElectricityCarrier,
-    #     HeatCarrier,
-    #     NaturalGasCarrier,
-    #     NaturalGasBoiler,
-    #     Photovoltaics,
-    #     NaturalGasStorage,
-    #     PumpedHydro,
-    #     NaturalGasPipeline,
-    # )
     importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
 
     config = Config.load_from_yaml(CONFIG_PATH)
     config.source_path = str(EXISTING_MODEL_PATH)
-    config.elements.insert.energy_system = "energy_system"
 
     model = Model.from_config(config)
     model.output_folder = OUTPUT_FOLDER
     model.name = "test_from_config_existing_model_replica"
+    model.build()
+    model.write()
+
+    compare_trees(EXISTING_MODEL_PATH, model.output_path, raise_error=True)
+
+def test_from_config_str():
+    """Recreate the existing_model fixture tree from config and explicit classes.
+
+    Calls the config file via a string path instead of a Config object.
+
+    Note: Element classes are imported locally to prevent global registry
+    contamination when this test runs alongside other tests.
+    """
+
+    importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
+
+    model = Model.from_config(CONFIG_PATH)
+    model.output_folder = OUTPUT_FOLDER
+    model.name = "test_from_config_str_existing_model_replica"
     model.build()
     model.write()
 

--- a/tests/end_to_end/test_from_config.py
+++ b/tests/end_to_end/test_from_config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 
+import tests.end_to_end.fixtures.existing_model_elements as existing_model_elements
 from zen_creator.model import Model
 from zen_creator.utils.compare_trees import compare_trees
 from zen_creator.utils.default_config import Config
@@ -25,7 +26,7 @@ def test_from_config():
     Note: Element classes are imported locally to prevent global registry
     contamination when this test runs alongside other tests.
     """
-    importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
+    importlib.reload(existing_model_elements)
 
     config = Config.load_from_yaml(CONFIG_PATH)
     config.source_path = str(EXISTING_MODEL_PATH)
@@ -38,6 +39,7 @@ def test_from_config():
 
     compare_trees(EXISTING_MODEL_PATH, model.output_path, raise_error=True)
 
+
 def test_from_config_str():
     """Recreate the existing_model fixture tree from config and explicit classes.
 
@@ -46,8 +48,7 @@ def test_from_config_str():
     Note: Element classes are imported locally to prevent global registry
     contamination when this test runs alongside other tests.
     """
-
-    importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
+    importlib.reload(existing_model_elements)
 
     model = Model.from_config(CONFIG_PATH)
     model.output_folder = OUTPUT_FOLDER

--- a/tests/end_to_end/test_from_config.py
+++ b/tests/end_to_end/test_from_config.py
@@ -1,0 +1,52 @@
+"""Test for creating models from config using custom element classes.
+
+Element classes are imported locally within the test function to avoid
+registering them globally, which would cause contamination of other tests.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from zen_creator.model import Model
+from zen_creator.utils.compare_trees import compare_trees
+from zen_creator.utils.default_config import Config
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures"
+EXISTING_MODEL_PATH = FIXTURE_ROOT / "existing_model"
+CONFIG_PATH = FIXTURE_ROOT / "config_existing_model.yaml"
+OUTPUT_FOLDER = Path(".//tests//end_to_end//outputs")
+
+
+def test_from_config():
+    """Recreate the existing_model fixture tree from config and explicit classes.
+
+    Note: Element classes are imported locally to prevent global registry
+    contamination when this test runs alongside other tests.
+    """
+    # Import element classes locally to prevent registry contamination
+    # from tests.end_to_end.existing_model_elements import (
+    #     ExistingModelEnergySystem,
+    #     ElectricityCarrier,
+    #     HeatCarrier,
+    #     NaturalGasCarrier,
+    #     NaturalGasBoiler,
+    #     Photovoltaics,
+    #     NaturalGasStorage,
+    #     PumpedHydro,
+    #     NaturalGasPipeline,
+    # )
+    importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
+
+    config = Config.load_from_yaml(CONFIG_PATH)
+    config.source_path = str(EXISTING_MODEL_PATH)
+    config.elements.insert.energy_system = "energy_system"
+
+    model = Model.from_config(config)
+    model.output_folder = OUTPUT_FOLDER
+    model.name = "test_from_config_existing_model_replica"
+    model.build()
+    model.write()
+
+    compare_trees(EXISTING_MODEL_PATH, model.output_path, raise_error=True)

--- a/tests/end_to_end/test_from_existing.py
+++ b/tests/end_to_end/test_from_existing.py
@@ -1,8 +1,74 @@
 import importlib
 from pathlib import Path
 
+import tests.end_to_end.fixtures.existing_model_elements as existing_model_elements
+from zen_creator.elements import (
+    GenericCarrier,
+    GenericConversionTechnology,
+    GenericEnergySystem,
+    GenericRetrofittingTechnology,
+    GenericStorageTechnology,
+    GenericTransportTechnology,
+)
 from zen_creator.model import Model
 from zen_creator.utils.compare_trees import compare_trees
+
+
+def _is_generic(element) -> bool:
+    """Check if the element is an instance of any generic type."""
+    return isinstance(
+        element,
+        (
+            GenericCarrier,
+            GenericConversionTechnology,
+            GenericRetrofittingTechnology,
+            GenericStorageTechnology,
+            GenericTransportTechnology,
+            GenericEnergySystem,
+        ),
+    )
+
+
+def _all_types_generic(model: Model) -> None:
+    """Check that all elements in the model are generic types.
+
+    This is used to verify that no custom element classes were registered
+    when loading from an existing model without a config. Raises an AssertionError
+    if any non-generic types are found.
+    """
+    for element in model.elements.values():
+        if not _is_generic(element):
+            raise AssertionError(
+                f"Expected generic Element, got {element.__class__.__name__}"
+            )
+
+    # Check that the energy system is a generic type
+    if not _is_generic(model.energy_system):
+        raise AssertionError(
+            "Expected generic EnergySystem, got "
+            f"{model.energy_system.__class__.__name__}"
+        )
+
+
+def _no_types_generic(model: Model) -> None:
+    """Check that no elements in the model are generic types.
+
+    This is used to verify that all custom element classes were registered
+    when loading from an existing model with a config. Raises an AssertionError
+    if any generic types are found.
+    """
+    for element in model.elements.values():
+        if _is_generic(element):
+            raise AssertionError(
+                "Expected non-generic Element, got " f"{element.__class__.__name__}"
+            )
+
+    # Check that the energy system is a non-generic type
+    if _is_generic(model.energy_system):
+        raise AssertionError(
+            "Expected non-generic EnergySystem, got "
+            f"{model.energy_system.__class__.__name__}"
+        )
 
 
 def test_crystal_ball():
@@ -39,6 +105,9 @@ def test_crystal_ball():
     # Compares file trees and files
     compare_trees(existing_model_path, model.output_path, raise_error=True)
 
+    # Check that all elements are generic types (i.e. no custom classes were registered)
+    _all_types_generic(model)
+
 
 def test_from_existing():
     """
@@ -67,6 +136,9 @@ def test_from_existing():
     # Compares file trees and files
     compare_trees(existing_model_path, model.output_path, raise_error=True)
 
+    # check that no types are generic (i.e. all custom classes were registered)
+    _all_types_generic(model)
+
 
 def test_from_existing_with_config():
     """
@@ -82,7 +154,10 @@ def test_from_existing_with_config():
     The current test case matches ``test_8a`` in ZEN-garden.
     """
     # import element classes locally to avoid global registry contamination
-    importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
+    # importing custom element classes registers them in the Element registry,
+    # This allows the elements to be assigned to the custom classes upon
+    # model creation.
+    importlib.reload(existing_model_elements)
 
     # set file paths
     existing_model_path = Path(".//tests//end_to_end//fixtures//existing_model")
@@ -97,6 +172,5 @@ def test_from_existing_with_config():
     # Compares file trees and files
     compare_trees(existing_model_path, model.output_path, raise_error=True)
 
-
-if __name__ == "__main__":
-    test_from_existing()
+    # check that no types are generic (i.e. all custom classes were registered)
+    _no_types_generic(model)

--- a/tests/end_to_end/test_from_existing.py
+++ b/tests/end_to_end/test_from_existing.py
@@ -1,3 +1,4 @@
+import importlib
 from pathlib import Path
 
 from zen_creator.model import Model
@@ -80,6 +81,8 @@ def test_from_existing_with_config():
 
     The current test case matches ``test_8a`` in ZEN-garden.
     """
+    # import element classes locally to avoid global registry contamination
+    importlib.import_module("tests.end_to_end.fixtures.existing_model_elements")
 
     # set file paths
     existing_model_path = Path(".//tests//end_to_end//fixtures//existing_model")

--- a/zen_creator/elements/energy_systems/energy_system.py
+++ b/zen_creator/elements/energy_systems/energy_system.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -285,6 +286,17 @@ class EnergySystem(Element, ABC):
                 "enter the nodes and coordinates as a `df`."
             )
         self._set_edges = value
+
+    # ---------- Property Overloads --------
+    @property
+    def relative_output_path(self) -> Path:
+        """Get the relative output path for the energy system.
+
+        Returns:
+            Path: The relative path for output files.
+        """
+
+        return Path("./energy_system")
 
     # ---------- Method Overloads --------
 

--- a/zen_creator/utils/attribute.py
+++ b/zen_creator/utils/attribute.py
@@ -82,8 +82,8 @@ class Attribute:
         self,
         name: str,
         element: Element,
-        unit: str | None = None,
         default_value: DefaultValue = None,
+        unit: str | None = None,
         base_technology: str | None = None,
         df: DataFrame | None = None,
         year_specific_dfs: dict[int, DataFrame] | None = None,
@@ -95,9 +95,12 @@ class Attribute:
         Args:
             name: The name of the attribute.
             element: The element this attribute belongs to.
-            unit: The unit of measurement for this attribute (optional).
             default_value: Default value for the attribute (optional).
+            unit: The unit of measurement for this attribute (optional).
+            base_technology: Base technology for retrofit_flow_coupling_factor
+                (optional).
             df: Time-series data as a pandas DataFrame or Series (optional).
+            year_specific_dfs: Year-specific data frames (optional).
             yearly_variations_df: Yearly variation factors (optional).
             sources: Ordered source information entries for this attribute (optional).
         """

--- a/zen_creator/utils/default_config.py
+++ b/zen_creator/utils/default_config.py
@@ -211,12 +211,8 @@ class SystemConfig(Subscriptable):
 # ------- Dataset configurations ----------------------------
 
 
-class ENSOEAPIConfig(Subscriptable):
-    api_key: Optional[str] = None
-
-
 class DatasetConfig(Subscriptable):
-    ensoe_api: ENSOEAPIConfig = Field(default_factory=ENSOEAPIConfig)
+    setting: bool = True
 
 
 class DatasetCollectionConfig(Subscriptable):

--- a/zen_creator/utils/registry.py
+++ b/zen_creator/utils/registry.py
@@ -56,3 +56,11 @@ class Registry(Generic[T]):
             return cls._registry[name]
         else:
             return None
+
+    @classmethod
+    def clear_registry(cls):
+        cls._registry.clear()
+
+    @classmethod
+    def update_registry(cls, new_registry: Dict[str, Type[T]]):
+        cls._registry.update(new_registry)


### PR DESCRIPTION
## Summary

Adds a test for the model.from_config() constructor that includes custom element classes.


Closes # (if applicable).


## Detailed list of changes

- chore: add end-to-end test for `model.from_config()`. The test demonstrates the usage of this constructor.

## Checklist

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.


### Code quality
- [x] Newly introduced dependencies are added to `pyproject.toml`.
- [x] Code changes have been tested locally and all tests pass.
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.
- [x] Type Checker  ``mypy .`` passes all checks.

