### PR TITLE
Fix defaults on dynamic config creation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,6 @@ extensions = [
     "myst_parser",
     "sphinx.ext.imgconverter",  # for SVG conversion
     "sphinxcontrib.mermaid",  # for class diagrams
-    "docstring",  # custom extension for inserting docstring text
 ]
 # allow errors in the notebooks
 nbsphinx_allow_errors = True

--- a/docs/files/api/carrier.rst
+++ b/docs/files/api/carrier.rst
@@ -16,13 +16,13 @@ Use Cases
 Examples
 --------
 
-.. code-block:: python
+The code below shows an example of how to implement a subclass of the
+``Carrier`` abstract class. Please read the docstrings
+carefully as they contain detailed information on required methods and
+syntax.
 
-   from zen_creator import Carrier
-
-   # Typically extended in project-specific implementations.
-   class MyCarrier(Carrier):
-       pass
+.. literalinclude:: ../../../zen_creator/elements/carriers/aa_template.py
+   :language: python
 
 .. rubric:: Summary
 

--- a/docs/files/api/energy_system.rst
+++ b/docs/files/api/energy_system.rst
@@ -15,13 +15,14 @@ Use Cases
 Examples
 --------
 
-.. code-block:: python
+The code below shows an example of how to implement a subclass of the
+``EnergySystem`` abstract class. Please read the docstrings
+carefully as they contain detailed information on required methods and
+syntax.
 
-   from zen_creator import EnergySystem
+.. literalinclude:: ../../../zen_creator/elements/energy_systems/aa_template.py
+   :language: python
 
-   # Typically extended in project-specific implementations.
-   class MyEnergySystem(EnergySystem):
-       pass
 
 .. rubric:: Summary
 

--- a/zen_creator/elements/carriers/aa_template.py
+++ b/zen_creator/elements/carriers/aa_template.py
@@ -5,8 +5,33 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from zen_creator.model import Model
 
-from zen_creator.elements import Carrier
-from zen_creator.utils.attribute import Attribute
+from zen_creator import Attribute, Carrier, CarrierConfig
+
+
+class TemplateCarrierConfig(CarrierConfig):
+    """
+    Configuration class for the TemplateCarrier.
+
+    This class is used to define the configuration parameters for the
+    TemplateCarrier.
+
+    By inheriting from CarrierConfig, these configurations
+    are automatically included in the Config under
+    Config().data.carrier.<carrier_name>.
+    This requires the the class has been imported (i.e. registered) before
+    the config is created.
+
+    Note: All configurations must have default values. The name must match
+    the name of the carrier class.
+    """
+
+    # TODO: state name of the carrier to which the config applies
+    name: str = "template_carrier"
+
+    # TODO: add any additional configuration parameters specific to
+    # the carrier here
+    carrier_setting_1: str = "default_value_1"
+    carrier_setting_2: float = 0.8
 
 
 class TemplateCarrier(Carrier):

--- a/zen_creator/elements/conversion_technologies/aa_template.py
+++ b/zen_creator/elements/conversion_technologies/aa_template.py
@@ -5,10 +5,40 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from zen_creator.model import Model
 
+from zen_creator import (
+    Attribute,
+    ConversionTechnology,
+    ConversionTechnologyConfig,
+    MetaData,
+    SourceInformation,
+)
 from zen_creator.datasets.datasets import TemplateDataset
-from zen_creator.datasets.datasets.metadata import MetaData, SourceInformation
-from zen_creator.elements import ConversionTechnology
-from zen_creator.utils.attribute import Attribute
+
+
+class TemplateConversionTechnologyConfig(ConversionTechnologyConfig):
+    """
+    Configuration class for the TemplateConversionTechnology.
+
+    This class is used to define the configuration parameters for the
+    TemplateConversionTechnology.
+
+    By inheriting from ConversionTechnologyConfig, these configurations
+    are automatically included in the Config under
+    Config().data.conversion_technology.<technology_name>.
+    This requires the the class has been imported (i.e. registered) before
+    the config is created.
+
+    Note: All configurations must have default values. The name must match
+    the name of the technology class.
+    """
+
+    # TODO: state name of the technology to which the config applies
+    name: str = "template_conversion_technology"
+
+    # TODO: add any additional configuration parameters specific to
+    # the technology here
+    conversion_technology_setting_1: str = "default_value_1"
+    conversion_technology_setting_2: float = 0.8
 
 
 class TemplateConversionTechnology(ConversionTechnology):

--- a/zen_creator/elements/element.py
+++ b/zen_creator/elements/element.py
@@ -209,7 +209,7 @@ class Element(ABC, Registry["Element"], is_base_registry=True):
             if attr.sources:
                 has_sources = True
                 output_lines.extend([attr_name, "-" * len(attr_name), ""])
-                output_lines.append(attr.sources_to_string())
+                output_lines.append(attr.sources_to_str())
                 output_lines.append("")
 
         if not has_sources:

--- a/zen_creator/elements/storage_technologies/aa_template.py
+++ b/zen_creator/elements/storage_technologies/aa_template.py
@@ -5,10 +5,40 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from zen_creator.model import Model
 
+from zen_creator import (
+    Attribute,
+    MetaData,
+    SourceInformation,
+    StorageTechnology,
+    StorageTechnologyConfig,
+)
 from zen_creator.datasets.datasets import TemplateDataset
-from zen_creator.datasets.datasets.metadata import MetaData, SourceInformation
-from zen_creator.elements import StorageTechnology
-from zen_creator.utils.attribute import Attribute
+
+
+class TemplateStorageTechnologyConfig(StorageTechnologyConfig):
+    """
+    Configuration class for the TemplateStorageTechnology.
+
+    This class is used to define the configuration parameters for the
+    TemplateStorageTechnology.
+
+    By inheriting from StorageTechnologyConfig, these configurations
+    are automatically included in the Config under
+    Config().data.storage_technology.<technology_name>.
+    This requires the the class has been imported (i.e. registered) before
+    the config is created.
+
+    Note: All configurations must have default values. The name must match
+    the name of the technology class.
+    """
+
+    # TODO: state name of the technology to which the config applies
+    name: str = "template_storage_technology"
+
+    # TODO: add any additional configuration parameters specific to
+    # the technology here
+    storage_technology_setting_1: str = "default_value_1"
+    storage_technology_setting_2: float = 0.8
 
 
 class TemplateStorageTechnology(StorageTechnology):

--- a/zen_creator/elements/transport_technologies/aa_template.py
+++ b/zen_creator/elements/transport_technologies/aa_template.py
@@ -5,10 +5,40 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from zen_creator.model import Model
 
+from zen_creator import (
+    Attribute,
+    MetaData,
+    SourceInformation,
+    TransportTechnology,
+    TransportTechnologyConfig,
+)
 from zen_creator.datasets.datasets import TemplateDataset
-from zen_creator.datasets.datasets.metadata import MetaData, SourceInformation
-from zen_creator.elements import TransportTechnology
-from zen_creator.utils.attribute import Attribute
+
+
+class TemplateTransportTechnologyConfig(TransportTechnologyConfig):
+    """
+    Configuration class for the TemplateTransportTechnology.
+
+    This class is used to define the configuration parameters for the
+    TemplateTransportTechnology.
+
+    By inheriting from TransportTechnologyConfig, these configurations
+    are automatically included in the Config under
+    Config().data.transport_technology.<technology_name>.
+    This requires the the class has been imported (i.e. registered) before
+    the config is created.
+
+    Note: All configurations must have default values. The name must match
+    the name of the technology class.
+    """
+
+    # TODO: state name of the technology to which the config applies
+    name: str = "template_transport_technology"
+
+    # TODO: add any additional configuration parameters specific to
+    # the technology here
+    transport_technology_setting_1: str = "default_value_1"
+    transport_technology_setting_2: float = 0.8
 
 
 class TemplateTransportTechnology(TransportTechnology):

--- a/zen_creator/utils/config/data.py
+++ b/zen_creator/utils/config/data.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Any, Dict, Type
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from zen_creator.utils.registry import Registry
 
@@ -20,7 +20,6 @@ class DatasetCollectionConfig(
     ABC, Subscriptable, Registry["DatasetCollectionConfig"], is_base_registry=True
 ):
     name: str = "generic_dataset_collection_config"
-    type: str
     model_config = ConfigDict(extra="forbid")
 
 
@@ -28,7 +27,6 @@ class TechnologyConfig(
     ABC, Subscriptable, Registry["TechnologyConfig"], is_base_registry=True
 ):
     name: str = "generic_technology_config"
-    type: str
     model_config = ConfigDict(extra="forbid")
 
 
@@ -36,7 +34,6 @@ class CarrierConfig(
     ABC, Subscriptable, Registry["CarrierConfig"], is_base_registry=True
 ):
     name: str = "generic_carrier_config"
-    type: str
     model_config = ConfigDict(extra="forbid")
 
 
@@ -44,7 +41,6 @@ class ConversionTechnologyConfig(
     ABC, Subscriptable, Registry["ConversionTechnologyConfig"], is_base_registry=True
 ):
     name: str = "generic_conversion_tech_config"
-    type: str
     model_config = ConfigDict(extra="forbid")
 
 
@@ -52,7 +48,6 @@ class StorageTechnologyConfig(
     ABC, Subscriptable, Registry["StorageTechnologyConfig"], is_base_registry=True
 ):
     name: str = "generic_storage_tech_config"
-    type: str
     model_config = ConfigDict(extra="forbid")
 
 
@@ -60,14 +55,13 @@ class TransportTechnologyConfig(
     ABC, Subscriptable, Registry["TransportTechnologyConfig"], is_base_registry=True
 ):
     name: str = "generic_transport_tech_config"
-    type: str
     model_config = ConfigDict(extra="forbid")
 
 
 class DataConfig(Subscriptable):
     """Config container for data operations."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", validate_default=True)
 
     dataset: Dict[str, DatasetConfig] = Field(default_factory=dict)
     dataset_collection: Dict[str, DatasetCollectionConfig] = Field(default_factory=dict)
@@ -87,29 +81,52 @@ class DataConfig(Subscriptable):
         user_input_dict: Dict[str, Any],
         base_config_cls: Type[Any],
     ) -> Dict[str, Any]:
-        discovered_defaults = {
-            name: {"type": cls_type.__name__}
+        """Helper method to process a registry field in the config.
+
+        This method takes the user input for a specific registry (e.g. datasets,
+        technologies, etc.) and merges it with the discovered defaults from the
+        registry. It then validates each user-provided configuration against the
+        appropriate class from the registry, ensuring that all entries are valid and
+        that all registered subclasses are included in the final config, even if the
+        user did not specify them.
+
+        Args:
+            user_input_dict: The dictionary of user-provided configurations for a
+                specific registry.
+            base_config_cls: The base configuration class for the registry (e.g.
+                DatasetConfig, TechnologyConfig, etc.), which is used to access the
+                registry and validate the user input.                       
+
+        Returns:
+            A dictionary containing the merged and validated configurations for the
+            registry, including both user-provided entries and defaults for any
+            registered subclasses that were not specified by the user.
+        """
+
+        # make sure all registered subclasses are included in the
+        # config, even if the user did not specify them
+        discovered_defaults: Dict[str, Any] = {
+            name: {}
             for name, cls_type in base_config_cls.get_registry().items()
-            if cls_type != base_config_cls and hasattr(cls_type, "name")
+            if cls_type != base_config_cls and issubclass(cls_type, base_config_cls)
         }
 
         merged_payload = {**discovered_defaults, **user_input_dict}
 
-        registered_classes = {
-            c.__name__: c
-            for c in base_config_cls.get_registry().values()
-            if c != base_config_cls and issubclass(c, BaseModel)
-        }
-
+        # validate each entry with the appropriate class
         validated_payload: Dict[str, Any] = {}
         for name, value in merged_payload.items():
             if isinstance(value, dict):
-                value_type = value.get("type")
-                target_cls = registered_classes.get(value_type)
+                target_cls = base_config_cls.get_by_name(name)
                 if target_cls is not None:
                     validated_payload[name] = target_cls.model_validate(value)
                     continue
-
+                else:
+                    raise ValueError(
+                        f"Invalid configuration entry '{name}' for registry of type "
+                        f"{base_config_cls.__name__}. No matching class found in the "
+                        f"registry."
+                    )
             validated_payload[name] = value
 
         return validated_payload
@@ -117,6 +134,14 @@ class DataConfig(Subscriptable):
     @model_validator(mode="before")
     @classmethod
     def populate_and_validate_registries(cls, data: Any) -> Any:
+        """Validate and populate fields in the data config.
+
+        This validator ensures that all registered subclasses of the various
+        config types (e.g. DatasetConfig, TechnologyConfig, etc.) are included
+        in the config, even if the user did not specify them. It also
+        validates any user-provided configurations against the appropriate
+        classes from the registry.
+        """
         if not isinstance(data, dict):
             data = {}
 

--- a/zen_creator/utils/config/data.py
+++ b/zen_creator/utils/config/data.py
@@ -12,7 +12,6 @@ class DatasetConfig(
     ABC, Subscriptable, Registry["DatasetConfig"], is_base_registry=True
 ):
     name: str = "generic_dataset_config"
-    type: str
     model_config = ConfigDict(extra="forbid")
 
 

--- a/zen_creator/utils/config/data.py
+++ b/zen_creator/utils/config/data.py
@@ -94,7 +94,7 @@ class DataConfig(Subscriptable):
                 specific registry.
             base_config_cls: The base configuration class for the registry (e.g.
                 DatasetConfig, TechnologyConfig, etc.), which is used to access the
-                registry and validate the user input.                       
+                registry and validate the user input.
 
         Returns:
             A dictionary containing the merged and validated configurations for the


### PR DESCRIPTION
## Summary

The previous version of ZEN-creator allowed elements to have custom configs; however, calling Config() did not automatically create default values for all element configurations. This pull request addresses the issue.

The pull request also fixes a bug in sources_to_str() for elements.

## Detailed list of changes

- fix: fix default config creation for custom element configs. Calling ``Config()`` now creates default values for all element-specific configurations.
- fix: repair ``sources_to_str()`` for elements by updating function call name.
- docs: document element-specific configurations by adding them to the template files.

## Checklist

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.


### Code quality
- [x] Newly introduced dependencies are added to `pyproject.toml`.
- [x] Code changes have been tested locally and all tests pass.
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.
- [x] Type Checker  ``mypy .`` passes all checks.

