### PR TITLE
Write sources to sources.md along attribute.json files.

### DIFF
--- a/zen_creator/elements/element.py
+++ b/zen_creator/elements/element.py
@@ -150,6 +150,9 @@ class Element(ABC, Registry["Element"], is_base_registry=True):
         # write attributes.json file
         self.save_attributes()
 
+        # write sources.md file
+        self.save_sources()
+
         # write data files
         self.save_data()
 
@@ -169,7 +172,6 @@ class Element(ABC, Registry["Element"], is_base_registry=True):
         """
         output = {}
         for attr_name in self._attribute_names:
-
             attr = getattr(self, attr_name)
 
             # skip for attributes such as set_nodes or set_edges with not default
@@ -186,6 +188,19 @@ class Element(ABC, Registry["Element"], is_base_registry=True):
         output = self.attributes_to_dict()
         with (out_path / "attributes.json").open("w") as f:
             json.dump(output, f, indent=4)
+
+    def save_sources(self):
+        """Save the element's sources to sources.md."""
+        if not any(
+            getattr(self, attr_name).sources for attr_name in self._attribute_names
+        ):
+            return
+
+        logger.debug(f"Saving 'sources.md' for element '{self.name}.'")
+
+        out_path = self.output_path
+        with (out_path / "sources.md").open("w") as f:
+            f.write(self.sources_to_str())
 
     def save_data(self):
         """Save the element's data files."""

--- a/zen_creator/model.py
+++ b/zen_creator/model.py
@@ -733,7 +733,7 @@ class Model:
         for element in self.elements.values():
             element.write()
 
-        logger.info("Done")
+        logger.info("Done writing model")
 
     def write_system_file(self) -> None:
         """Write the system.json file for the model.

--- a/zen_creator/utils/compare_trees.py
+++ b/zen_creator/utils/compare_trees.py
@@ -2,6 +2,7 @@
 import difflib
 import json
 import logging
+from os.path import basename
 from pathlib import Path
 from typing import Any
 
@@ -187,6 +188,9 @@ def compare_trees(dir1: str | Path, dir2: str | Path, raise_error: bool = True) 
     log: list[str] = []
 
     for rel_path in sorted(all_paths):
+        if basename(rel_path) == "sources.md":
+            continue  # ignore sources.md files since they are not in the fixtures
+
         f1 = map1.get(rel_path)
         f2 = map2.get(rel_path)
 


### PR DESCRIPTION
## Summary

The source of element's attributes are written to the file `sources.md` and stored at the same location as `attribute.json`.

## Detailed list of changes

- feat: write sources to sources.md along attribute.json files.

## Checklist

### PR structure
- [x] The PR has a descriptive title.
- [x] A detailed list of changes is provided.


### Code quality
- [x] Code changes have been tested locally and all tests pass.
- [x] Code has been formatted via ``black .`` in a terminal window.
- [x] Linter ``ruff check .`` passes all checks.
- [x] Type Checker  ``mypy .`` passes all checks.

